### PR TITLE
Check $view parameter before introtext word limit

### DIFF
--- a/components/com_k2/models/item.php
+++ b/components/com_k2/models/item.php
@@ -188,7 +188,7 @@ class K2ModelItem extends K2Model
             }
         }
 
-        if ($item->params->get('catItemIntroTextWordLimit') && $task == 'category') {
+        if ($item->params->get('catItemIntroTextWordLimit') && $task == 'category' && $view != 'item') {
             $item->introtext = K2HelperUtilities::wordLimit($item->introtext, $item->params->get('catItemIntroTextWordLimit'));
         }
 


### PR DESCRIPTION
When displaying an item, intro text should only be limited if the task is category and the view is not set to item